### PR TITLE
[bugfix] Apply filter to actor authority instead of target inbox authority

### DIFF
--- a/src/jobs/apub/announce.rs
+++ b/src/jobs/apub/announce.rs
@@ -55,7 +55,7 @@ impl Announce {
         let inboxes = get_inboxes(&state.state, &self.actor, &self.object_id).await?;
         state
             .job_server
-            .queue(DeliverMany::new(inboxes, announce, true)?)
+            .queue(DeliverMany::new(inboxes, announce, authority.to_owned(), true)?)
             .await?;
 
         state.state.cache(self.object_id, activity_id);

--- a/src/jobs/apub/forward.rs
+++ b/src/jobs/apub/forward.rs
@@ -36,11 +36,15 @@ impl Forward {
             .as_single_id()
             .ok_or(ErrorKind::MissingId)?;
 
+        let authority = self.actor.id.authority_str().ok_or_else(|| {
+            ErrorKind::MissingDomain
+        })?;
+
         let inboxes = get_inboxes(&state.state, &self.actor, object_id).await?;
 
         state
             .job_server
-            .queue(DeliverMany::new(inboxes, self.input, false)?)
+            .queue(DeliverMany::new(inboxes, self.input, authority.to_owned(), false)?)
             .await?;
 
         Ok(())


### PR DESCRIPTION
Currently, there is a bug which filter applies to target inbox authority, which renders subscription filter totally useless.

This patch fixes that bug.