### PR TITLE
Enhances Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,22 @@
-FROM rust:1-alpine3.18 AS builder
+ARG ALPINE_VER="3.18"
+
+FROM rust:1-alpine${ALPINE_VER} AS builder
 
 RUN apk add --no-cache openssl libc-dev openssl-dev protobuf protobuf-dev
 
-RUN mkdir -p /opt/aode-relay
 WORKDIR /opt/aode-relay
 
+ADD Cargo.lock Cargo.toml /opt/aode-relay/
+RUN cargo fetch
+
 ADD . /opt/aode-relay
+RUN cargo build --frozen --release
 
-RUN cargo build --release
+################################################################################
 
+FROM alpine:${ALPINE_VER}
 
-FROM alpine:3.18
-
-RUN apk add --no-cache openssl ca-certificates tini
-
-ENTRYPOINT ["/sbin/tini", "--"]
+RUN apk add --no-cache openssl ca-certificates curl tini
 
 COPY --from=builder /opt/aode-relay/target/release/relay /usr/bin/aode-relay
 
@@ -23,13 +25,20 @@ ENV ADDR 0.0.0.0
 ENV PORT 8080
 ENV DEBUG false
 ENV VALIDATE_SIGNATURES true
-ENV HTTPS true
+ENV HTTPS false
 ENV PRETTY_LOG false
 ENV PUBLISH_BLOCKS true
-ENV SLED_PATH /opt/aode-relay/sled/db-0.34
+ENV SLED_PATH "/var/lib/aode-relay/sled/db-0.34"
 ENV RUST_LOG warn
-# Since this container is intended to run behind reverse proxy
-# we don't need HTTPS in here.
-ENV HTTPS false
+ENV PROMETHEUS_ADDR 0.0.0.0
+ENV PROMETHEUS_PORT 8081
+
+VOLUME "/var/lib/aode-relay/sled"
+
+ENTRYPOINT ["/sbin/tini", "--"]
 
 CMD ["/usr/bin/aode-relay"]
+
+EXPOSE 8080 8081
+
+HEALTHCHECK CMD curl --silent --fail "localhost:$PORT/.well-known/nodeinfo" > /dev/null || exit 1


### PR DESCRIPTION
* Split `cargo` `fetch` and `build` for Docker caching
* Add `curl` for health-check.
* Add health-check
* Change `/opt/aode-relay/sled/db-0.34` paths to `/var/lib/aode-relay/sled/db-0.34`
* Make `/var/lib/aode-relay/sled` as VOLUME
* Enable Prometheus on 8081
* Expose ports