### PR TITLE
Changes "/var/lib/aode-relay/sled" to "/var/lib/aode-relay"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV RUST_LOG warn
 ENV PROMETHEUS_ADDR 0.0.0.0
 ENV PROMETHEUS_PORT 8081
 
-VOLUME "/var/lib/aode-relay/sled"
+VOLUME "/var/lib/aode-relay"
 
 ENTRYPOINT ["/sbin/tini", "--"]
 


### PR DESCRIPTION
It should be mark `/var/lib/aode-relay/` as Volume instead of `sled` only.